### PR TITLE
refactor#58 : 임시토큰 발급 추가 (#58)

### DIFF
--- a/src/main/java/com/back/domain/member/controller/AuthController.java
+++ b/src/main/java/com/back/domain/member/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.back.domain.member.repository.MemberRepository;
 import com.back.domain.member.service.AuthService;
 import com.back.domain.member.service.MemberService;
 import com.back.global.exception.ErrorCode;
+import com.back.global.jwt.JwtTokenProvider;
 import com.back.global.util.CookieUtil;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,6 +37,7 @@ public class AuthController {
     private final MemberService memberService;
     private final CookieUtil cookieUtil;
     private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(
         summary = "로그인",
@@ -168,12 +170,16 @@ public class AuthController {
             @Valid @RequestBody AdditionalInfoRequest request,
             HttpServletResponse response
     ) {
-        // memberId 유효성 검증
-        Long memberId = request.getMemberId();
-        if (memberId == null || memberId <= 0) {
-            log.error("memberId가 유효하지 않습니다. MemberId: {}", memberId);
+        // 임시 토큰 검증 및 memberId 추출
+        Long memberId;
+        try {
+            memberId = jwtTokenProvider.validateAndGetMemberIdFromTemporaryToken(
+                    request.getTemporaryToken()
+            );
+        } catch (IllegalArgumentException e) {
+            log.error("임시 토큰 검증 실패: {}", e.getMessage());
             throw new IllegalArgumentException(
-                com.back.global.exception.ErrorCode.INVALID_INPUT_VALUE.getMessage()
+                com.back.global.exception.ErrorCode.AUTH_TOKEN_INVALID.getMessage()
             );
         }
         

--- a/src/main/java/com/back/domain/member/dto/request/AdditionalInfoRequest.java
+++ b/src/main/java/com/back/domain/member/dto/request/AdditionalInfoRequest.java
@@ -2,7 +2,6 @@ package com.back.domain.member.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,8 +14,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AdditionalInfoRequest {
 
-    @NotNull(message = "회원 ID는 필수입니다.")
-    private Long memberId;
+    @NotBlank(message = "임시 토큰은 필수입니다.")
+    private String temporaryToken;
 
     @NotBlank(message = "닉네임은 필수입니다.")
     @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하로 입력해주세요.")

--- a/src/main/java/com/back/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/back/global/jwt/JwtTokenProvider.java
@@ -25,6 +25,8 @@ public class JwtTokenProvider {
 
     private static final String MEMBER_ID_CLAIM = "memberId";
     private static final String ROLE_CLAIM = "role";
+    private static final String TEMPORARY_TOKEN_TYPE = "temporary";
+    private final long temporaryTokenValidityInMilliseconds = 30 * 60 * 1000; // 30 minutes
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secret,
@@ -132,6 +134,44 @@ public class JwtTokenProvider {
                 .memberId(payload.get(MEMBER_ID_CLAIM, Long.class))
                 .role(payload.get(ROLE_CLAIM, String.class))
                 .build();
+    }
+
+    /** 임시 토큰 생성 (추가 정보 입력용, 30분 유효) */
+    public String createTemporaryToken(Long memberId) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + temporaryTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .claim(MEMBER_ID_CLAIM, memberId)
+                .claim("type", TEMPORARY_TOKEN_TYPE)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /** 임시 토큰 검증 및 회원 ID 추출 */
+    public Long validateAndGetMemberIdFromTemporaryToken(String token) {
+        // 토큰 유효성 검증
+        if (!validate(token)) {
+            throw new IllegalArgumentException("유효하지 않은 임시 토큰입니다.");
+        }
+
+        Claims payload = getPayload(token);
+        
+        // 토큰 타입 확인
+        String tokenType = payload.get("type", String.class);
+        if (!TEMPORARY_TOKEN_TYPE.equals(tokenType)) {
+            throw new IllegalArgumentException("유효하지 않은 임시 토큰 타입입니다.");
+        }
+
+        // memberId 추출
+        Long memberId = payload.get(MEMBER_ID_CLAIM, Long.class);
+        if (memberId == null) {
+            throw new IllegalArgumentException("임시 토큰에서 회원 ID를 찾을 수 없습니다.");
+        }
+
+        return memberId;
     }
 }
 

--- a/src/main/java/com/back/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/back/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -6,6 +6,7 @@ import com.back.domain.member.entity.SocialProvider;
 import com.back.domain.member.service.AuthService;
 import com.back.domain.member.service.SocialLoginService;
 import com.back.domain.member.util.OAuth2UserInfoFactory;
+import com.back.global.jwt.JwtTokenProvider;
 import com.back.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -30,6 +31,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final SocialLoginService socialLoginService;
     private final AuthService authService;
     private final CookieUtil cookieUtil;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Value("${app.oauth2.redirect-uri:http://localhost:3000/auth/callback}")
     private String redirectUri;
@@ -55,10 +57,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             // 추가 정보 입력 필요 여부 확인
             String targetUrl;
             if (member.isAdditionalInfoRequired()) {
-                // 추가 정보 입력이 필요한 경우: JWT 발급하지 않음 (회원 상태 미확정)
+                // 추가 정보 입력이 필요한 경우: 임시 토큰 발급 (회원 상태 미확정)
                 // OAuth 인증만 완료하고, JWT는 추가 정보 입력 완료 후에만 발급
+                String temporaryToken = jwtTokenProvider.createTemporaryToken(member.getId());
                 targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/login-additional")
-                        .queryParam("memberId", member.getId())
+                        .queryParam("token", temporaryToken)
                         .queryParam("provider", provider.name())
                         .build()
                         .toUriString();

--- a/src/test/java/com/back/domain/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/domain/member/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import com.back.domain.member.repository.MemberRepository;
 import com.back.domain.member.service.AuthService;
 import com.back.domain.member.service.MemberService;
 import com.back.global.exception.GlobalExceptionHandler;
+import com.back.global.jwt.JwtTokenProvider;
 import com.back.global.util.CookieUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,9 @@ public class AuthControllerTest {
 
     @MockitoBean
     private MemberRepository memberRepository;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     @DisplayName("1. 로그인 성공")


### PR DESCRIPTION


## 📌 개요

OAuth 인증 이후에 추가 입력 정보 대상을 확인 하기 위한 memberId 정보를 URL에 노출시키는 것은 보안 위협이 있다고 판단(다른 사용자가 memberId를 통해 필수 정보를 입력 할 수 있음)

-> 임시토큰을 발행하여 대상을 파악 하는 로직으로 변경 하고자 함

temporary token
유효시간 : 30분

-

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

-

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #{이슈 번호}

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
