### PR TITLE
feat#60 : 마이페이지용 API 추가 & 인증/인가 로직 수정 (#60)

### DIFF
--- a/src/main/java/com/back/domain/member/controller/AuthController.java
+++ b/src/main/java/com/back/domain/member/controller/AuthController.java
@@ -177,14 +177,10 @@ public class AuthController {
                     request.getTemporaryToken()
             );
         } catch (IllegalArgumentException e) {
-            log.error("임시 토큰 검증 실패: {}", e.getMessage());
             throw new IllegalArgumentException(
                 com.back.global.exception.ErrorCode.AUTH_TOKEN_INVALID.getMessage()
             );
         }
-        
-        log.info("추가 정보 입력 요청 - MemberId: {}, Nickname: {}, Email: {}", 
-                memberId, request.getNickname(), request.getEmail());
         
         // 추가 정보 입력 완료 처리
         memberService.completeAdditionalInfo(memberId, request.getNickname(), request.getEmail());
@@ -197,8 +193,6 @@ public class AuthController {
 
         // 추가 정보가 실제로 입력되었는지 확인 (null이나 blank 값이 들어온 경우 방지)
         if (member.isAdditionalInfoRequired()) {
-            log.error("추가 정보 입력이 완료되지 않았습니다. MemberId: {}, Nickname: {}, Email: {}", 
-                    memberId, member.getNickname(), member.getEmail());
             throw new IllegalArgumentException(
                 com.back.global.exception.ErrorCode.INVALID_INPUT_VALUE.getMessage()
             );

--- a/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.back.domain.member.dto.request.MemberUpdateRequest;
 import com.back.domain.member.dto.request.MemberWithdrawRequest;
 import com.back.domain.member.dto.request.NicknameCheckRequest;
 import com.back.domain.member.dto.response.EmailCheckResponse;
+import com.back.domain.member.dto.response.MemberCountsResponse;
 import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.dto.response.MemberWithdrawResponse;
 import com.back.domain.member.dto.response.NicknameCheckResponse;
@@ -48,6 +49,26 @@ public class MemberController {
         @AuthenticationPrincipal Long memberId
     ) {
         MemberInfoResponse response = memberService.getMemberInfo(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+        summary = "내 회원 정보 조회 Counts",
+        description = "현재 로그인한 회원의 통계 정보(좋아요, 댓글, 피드 개수)를 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = MemberCountsResponse.class))
+        ),
+        @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
+    @GetMapping("/me/counts")
+    public ResponseEntity<MemberCountsResponse> getMyCounts(
+        @AuthenticationPrincipal Long memberId
+    ) {
+        MemberCountsResponse response = memberService.getMemberCounts(memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/back/domain/member/dto/response/MemberCountsResponse.java
+++ b/src/main/java/com/back/domain/member/dto/response/MemberCountsResponse.java
@@ -1,0 +1,17 @@
+package com.back.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberCountsResponse {
+
+    private Long likedCount;      // 좋아요 개수
+    private Long commentedCount;  // 댓글 개수
+    private Long feedCount;       // 피드 개수
+}

--- a/src/main/java/com/back/domain/member/service/AuthService.java
+++ b/src/main/java/com/back/domain/member/service/AuthService.java
@@ -39,7 +39,8 @@ public class AuthService {
                         ErrorCode.MEMBER_NOT_FOUND.getMessage()
                 ));
 
-        refreshTokenRepository.findByMemberId(memberId).ifPresent(RefreshToken::revoke);
+        // 기존 Refresh Token 모두 삭제 (무효화만 하면 DB에 계속 쌓임)
+        refreshTokenRepository.deleteByMemberId(memberId);
 
         String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole().name());
         String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
@@ -54,9 +55,6 @@ public class AuthService {
                 .build());
 
         cookieUtil.setRefreshTokenCookie(response, refreshToken);
-        
-        log.info("로그인 성공 - Member ID: {}, Email: {}", 
-                member.getId(), member.getEmail() != null ? member.getEmail() : "(없음)");
 
         return accessToken;
     }
@@ -65,14 +63,10 @@ public class AuthService {
     /** 로그아웃 처리 */
     @Transactional
     public void logout(Long memberId, HttpServletResponse response) {
-        refreshTokenRepository.findByMemberId(memberId)
-                .ifPresent(refreshToken -> {
-                    refreshToken.revoke();
-                    refreshTokenRepository.save(refreshToken);
-                });
+        // Refresh Token 모두 삭제 (무효화만 하면 DB에 계속 쌓임)
+        refreshTokenRepository.deleteByMemberId(memberId);
+        
         cookieUtil.deleteRefreshTokenCookie(response);
-
-        log.info("로그아웃 성공 - Member ID: {}", memberId);
     }
 
     /** Access Token 갱신 */
@@ -99,12 +93,7 @@ public class AuthService {
         Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
 
-        String newAccessToken = jwtTokenProvider.createAccessToken(
-                member.getId(), member.getRole().name());
-
-        log.info("Access Token 갱신 성공 - Member ID: {}", memberId);
-
-        return newAccessToken;
+        return jwtTokenProvider.createAccessToken(member.getId(), member.getRole().name());
     }
 
     /** Refresh Token 만료 시간 계산 */
@@ -115,7 +104,6 @@ public class AuthService {
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
         } catch (Exception e) {
-            log.error("토큰 만료 시간 계산 실패", e);
             return LocalDateTime.now().plusDays(7);
         }
     }

--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -1,6 +1,10 @@
 package com.back.domain.member.service;
 
+import com.back.domain.comment.repository.CommentRepository;
+import com.back.domain.feed.repository.FeedReactionRepository;
+import com.back.domain.feed.repository.FeedRepository;
 import com.back.domain.member.dto.request.MemberUpdateRequest;
+import com.back.domain.member.dto.response.MemberCountsResponse;
 import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
@@ -19,6 +23,9 @@ import java.util.Random;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final FeedReactionRepository feedReactionRepository;
+    private final CommentRepository commentRepository;
+    private final FeedRepository feedRepository;
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int MEMBER_CODE_LENGTH = 8;
 
@@ -64,6 +71,27 @@ public class MemberService {
         return MemberInfoResponse.from(member);
     }
 
+    /** 회원 통계 정보 조회 (좋아요, 댓글, 피드 개수) */
+    public MemberCountsResponse getMemberCounts(Long memberId) {
+        // 회원 존재 여부 확인
+        getMember(memberId);
+
+        Long likedCount = feedReactionRepository.countByMemberId(memberId);
+        Long commentedCount = commentRepository.countByMemberIdAndDeletedAtIsNull(memberId);
+        Long feedCount = feedRepository.countByMemberIdAndDeletedAtIsNull(memberId);
+
+        // null 체크 (count 메서드는 null을 반환할 수 있으므로 0으로 처리)
+        likedCount = likedCount != null ? likedCount : 0L;
+        commentedCount = commentedCount != null ? commentedCount : 0L;
+        feedCount = feedCount != null ? feedCount : 0L;
+
+        return MemberCountsResponse.builder()
+                .likedCount(likedCount)
+                .commentedCount(commentedCount)
+                .feedCount(feedCount)
+                .build();
+    }
+
     public boolean checkNickname(String nickname) {
         return memberRepository.existsByNicknameAndDeletedAtIsNull(nickname);
     }
@@ -104,7 +132,6 @@ public class MemberService {
         }
 
         memberRepository.save(member);
-        log.info("회원 정보 수정 완료 - ID: {}", memberId);
     }
 
     @Transactional
@@ -119,7 +146,6 @@ public class MemberService {
 
         member.delete();
         memberRepository.save(member);
-        log.info("회원 탈퇴 완료 - ID: {}, 사유: {}", memberId, reason);
     }
 
     /** 추가 정보 입력 완료 (닉네임, 이메일 필수 입력) */
@@ -129,7 +155,6 @@ public class MemberService {
 
         // 이미 추가 정보가 입력된 경우
         if (!member.isAdditionalInfoRequired()) {
-            log.info("이미 추가 정보가 입력된 회원 - ID: {}", memberId);
             return;
         }
 
@@ -160,8 +185,6 @@ public class MemberService {
         }
 
         memberRepository.save(member);
-        log.info("추가 정보 입력 완료 - ID: {}, Nickname: {}, Email: {}", 
-                memberId, nickname, email);
     }
 }
 

--- a/src/main/java/com/back/domain/member/service/SocialLoginService.java
+++ b/src/main/java/com/back/domain/member/service/SocialLoginService.java
@@ -39,26 +39,30 @@ public class SocialLoginService {
             // 기존 소셜 계정이 있으면 해당 회원 반환 및 정보 업데이트
             Member member = existingAccount.getMember();
             
+            // 최신 데이터를 보장하기 위해 DB에서 다시 조회 (JPA 캐싱 이슈 방지)
+            Member freshMember = memberRepository.findByIdAndDeletedAtIsNull(member.getId())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            ErrorCode.MEMBER_NOT_FOUND.getMessage()
+                    ));
+            
             // 탈퇴한 회원인지 확인
-            if (member.isDeleted()) {
+            if (freshMember.isDeleted()) {
                 throw new IllegalArgumentException(
                         ErrorCode.MEMBER_ALREADY_DELETED.getMessage()
                 );
             }
 
             // 소셜 로그인에서 받은 최신 정보로 업데이트 (프로필 이미지, 이름 등이 변경되었을 수 있음)
-            updateMemberInfoFromSocialLogin(member, userInfo);
+            // 주의: nickname과 email은 업데이트하지 않음 (추가 정보 입력 페이지에서만 수정 가능)
+            updateMemberInfoFromSocialLogin(freshMember, userInfo);
 
             // 최근 로그인 정보 업데이트
             existingAccount.updateLastLogin();
-            member.updateLastLoginProvider(userInfo.getProvider());
+            freshMember.updateLastLoginProvider(userInfo.getProvider());
             memberSocialAccountRepository.save(existingAccount);
-            memberRepository.save(member);
+            memberRepository.save(freshMember);
 
-            log.info("기존 소셜 계정으로 로그인 - Provider: {}, ProviderId: {}, MemberId: {}",
-                    userInfo.getProvider(), userInfo.getProviderId(), member.getId());
-
-            return member;
+            return freshMember;
         }
 
         // 2. 소셜 계정이 없으면 새 회원 생성 (소셜 로그인으로만 가입 가능)
@@ -73,11 +77,7 @@ public class SocialLoginService {
         }
 
         // 이름 업데이트 (소셜 로그인에서 받은 최신 이름)
-        if (userInfo.getName() != null && !userInfo.getName().equals(member.getName())) {
-            // 이름은 변경하지 않고 로그만 남김 (이름 변경은 별도 API로 처리)
-            log.debug("소셜 로그인 이름 변경 감지 - 기존: {}, 새로운: {}", 
-                    member.getName(), userInfo.getName());
-        }
+        // 이름은 변경하지 않음 (이름 변경은 별도 API로 처리)
     }
 
     /** 새 회원 생성 (소셜 로그인 정보 저장, null 값 허용) */
@@ -123,12 +123,6 @@ public class SocialLoginService {
         // DB에 저장
         memberRepository.save(member);
         memberSocialAccountRepository.save(socialAccount);
-
-        log.info("새 회원 생성 및 소셜 계정 연결 - Provider: {}, ProviderId: {}, MemberId: {}, Email: {}, Name: {}, Nickname: {}",
-                userInfo.getProvider(), userInfo.getProviderId(), member.getId(), 
-                member.getEmail() != null ? member.getEmail() : "(없음)", 
-                member.getName() != null ? member.getName() : "(없음)",
-                member.getNickname() != null ? member.getNickname() : "(없음)");
 
         return member;
     }

--- a/src/main/java/com/back/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/back/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -3,9 +3,11 @@ package com.back.global.security;
 import com.back.domain.member.dto.OAuth2UserInfo;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.entity.SocialProvider;
+import com.back.domain.member.repository.MemberRepository;
 import com.back.domain.member.service.AuthService;
 import com.back.domain.member.service.SocialLoginService;
 import com.back.domain.member.util.OAuth2UserInfoFactory;
+import com.back.global.exception.ErrorCode;
 import com.back.global.jwt.JwtTokenProvider;
 import com.back.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,6 +34,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final AuthService authService;
     private final CookieUtil cookieUtil;
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
     @Value("${app.oauth2.redirect-uri:http://localhost:3000/auth/callback}")
     private String redirectUri;
@@ -54,26 +57,31 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             // 최근 로그인 방식을 쿠키에 저장
             cookieUtil.setLastLoginProviderCookie(response, provider.name());
 
-            // 추가 정보 입력 필요 여부 확인
+            // 트랜잭션 커밋 후 최신 데이터를 보장하기 위해 다시 조회
+            // (findOrCreateMember의 트랜잭션이 커밋된 후 최신 데이터 확인)
+            Member latestMember = memberRepository.findByIdAndDeletedAtIsNull(member.getId())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            ErrorCode.MEMBER_NOT_FOUND.getMessage()
+                    ));
+
+            // 추가 정보 입력 필요 여부 확인 (최신 데이터 기준)
             String targetUrl;
-            if (member.isAdditionalInfoRequired()) {
+            if (latestMember.isAdditionalInfoRequired()) {
                 // 추가 정보 입력이 필요한 경우: 임시 토큰 발급 (회원 상태 미확정)
                 // OAuth 인증만 완료하고, JWT는 추가 정보 입력 완료 후에만 발급
-                String temporaryToken = jwtTokenProvider.createTemporaryToken(member.getId());
+                String temporaryToken = jwtTokenProvider.createTemporaryToken(latestMember.getId());
                 targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/login-additional")
                         .queryParam("token", temporaryToken)
                         .queryParam("provider", provider.name())
                         .build()
                         .toUriString();
-                log.info("소셜 로그인 성공 (추가 정보 입력 필요) - Provider: {}, MemberId: {}", provider, member.getId());
             } else {
                 // 추가 정보 입력이 완료된 경우: JWT 발급 (회원 상태 확정)
-                authService.login(member.getId(), response);
+                authService.login(latestMember.getId(), response);
                 targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000")
                         .queryParam("provider", provider.name())
                         .build()
                         .toUriString();
-                log.info("소셜 로그인 성공 - Provider: {}, MemberId: {}", provider, member.getId());
             }
 
             getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/com/back/global/util/CookieUtil.java
+++ b/src/main/java/com/back/global/util/CookieUtil.java
@@ -28,7 +28,7 @@ public class CookieUtil {
 
     /** Refresh Token 쿠키 삭제 */
     public void deleteRefreshTokenCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, "");
         cookie.setHttpOnly(HTTP_ONLY);
         cookie.setSecure(SECURE);
         cookie.setPath("/");


### PR DESCRIPTION
## 📌 개요

1. 마이페이지용 API 추가
2. 인증/인가 로직 수정 (RT가 무효화 하는 기능으로 인해 DB에 중복 적제되던 오류가 발생) -> RT 삭제로 바꿔 중복 적제 방지

-

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

-

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #{이슈 번호}

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화
