### PR TITLE
fix : 프로필 이미지 수정 오류 해결 (#81)

### DIFF
--- a/src/main/java/com/back/domain/member/service/SocialLoginService.java
+++ b/src/main/java/com/back/domain/member/service/SocialLoginService.java
@@ -71,13 +71,13 @@ public class SocialLoginService {
 
     /** 소셜 로그인 최신 정보로 회원 정보 업데이트 */
     private void updateMemberInfoFromSocialLogin(Member member, OAuth2UserInfo userInfo) {
-        // 프로필 이미지 업데이트 (소셜 로그인에서 받은 최신 이미지)
-        if (userInfo.getProfileImageUrl() != null) {
-            member.updateProfileImage(userInfo.getProfileImageUrl());
+        // 프로필 이미지: 사용자가 직접 수정한 이미지는 소셜 이미지로 덮어쓰지 않음
+        String currentImageUrl = member.getProfileImageUrl();
+        String socialImageUrl = userInfo.getProfileImageUrl();
+        
+        if (socialImageUrl != null && (currentImageUrl == null || currentImageUrl.equals(socialImageUrl))) {
+            member.updateProfileImage(socialImageUrl);
         }
-
-        // 이름 업데이트 (소셜 로그인에서 받은 최신 이름)
-        // 이름은 변경하지 않음 (이름 변경은 별도 API로 처리)
     }
 
     /** 새 회원 생성 (소셜 로그인 정보 저장, null 값 허용) */


### PR DESCRIPTION
## 📌 개요

문제 : 프로필 이미지 수정 후 로그아웃/재로그인 시 원래 이미지로 되돌아가는 현상
원인 : 소셜 로그인 시 소셜에서 받은 이미지로 덮어써짐
수정 내용:
현재 DB의 프로필 이미지 URL과 소셜에서 받은 URL을 비교
현재 이미지가 없거나 소셜 이미지와 같을 때만 업데이트
현재 이미지가 있고 소셜 이미지와 다르면 업데이트하지 않음 (사용자가 수정한 이미지로 간주)

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

-

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #{이슈 번호}

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화
