### PR TITLE
fix: createdate가 null로 들어가는 문제 해결 (#72)

### DIFF
--- a/src/main/java/com/back/Application.java
+++ b/src/main/java/com/back/Application.java
@@ -2,9 +2,7 @@ package com.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
 

--- a/src/main/java/com/back/global/config/JpaConfig.java
+++ b/src/main/java/com/back/global/config/JpaConfig.java
@@ -1,0 +1,15 @@
+package com.back.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ * JPA Auditing 설정
+ * 
+ * @CreatedDate, @LastModifiedDate 자동 설정을 위한 Configuration
+ * BaseEntity를 상속받는 모든 엔티티에 자동으로 생성/수정 시간이 기록됩니다.
+ */
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- @EnableJpaAuditing 어노테이션을 추가
1. Spring이 AuditingEntityListener 활성화
2. @CreatedDate, @LastModifiedDate 감지
3. 엔티티 저장/수정 시 자동으로 시간 설정
---
수정.
@EnableJpaAuditing 어노테이션을 제거하고
JpaConfig를 새로 생성하였습니다. 이유는
@EnableJpaAuditing을 메인 클래스에 바로 붙이면
@WebMvcTest 같은 슬라이스 테스트에서 JPA 인프라가 없어서 터질 수 있어
깃허브 액션에서 막혔었고 테스트와 분리 시켜주었습니다.


## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 테스트 확인 완료 했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인