### PR TITLE
이미지 업로드 API에 PostMapping에 consumes 추가 (#155)

### DIFF
--- a/src/main/java/com/back/domain/feed/controller/ImageController.java
+++ b/src/main/java/com/back/domain/feed/controller/ImageController.java
@@ -51,7 +51,7 @@ public class ImageController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (파일이 없거나 이미지가 아님)"),
             @ApiResponse(responseCode = "500", description = "업로드 실패")
     })
-    @PostMapping("/upload")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ImageUploadResponse> uploadImage(
             @Parameter(
                     description = "업로드할 이미지 파일",
@@ -117,7 +117,7 @@ public class ImageController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (파일 개수 초과 등)"),
             @ApiResponse(responseCode = "500", description = "업로드 실패")
     })
-    @PostMapping("/upload-multiple")
+    @PostMapping(value = "/upload-multiple", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<List<ImageUploadResponse>> uploadMultipleImages(
             @Parameter(
                     description = "업로드할 이미지 파일들 (최대 10개)",


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 이미지 업로드 메서드에서 업로드 파일 명시화

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- 예시 이미지로 표현
<img width="1452" height="621" alt="{24B439C8-C617-40FC-88F4-654717C0DA05}" src="https://github.com/user-attachments/assets/9cf7a69c-299b-4d12-a1ce-2119bbd7295e" />
에서
<img width="1427" height="295" alt="{EF8BC6D3-B212-47CA-91E5-65EE795DF65C}" src="https://github.com/user-attachments/assets/a4b1b2e4-3dc3-464e-9ddf-779d19827910" />
로 변경됨
따라서 좀 더 테스트 해보기 편해짐

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #155 

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화
