### PR TITLE
버그 수정 (#163)

### DIFF
--- a/src/main/java/com/back/domain/donation/dto/DonationPaymentDto.java
+++ b/src/main/java/com/back/domain/donation/dto/DonationPaymentDto.java
@@ -3,6 +3,7 @@ package com.back.domain.donation.dto;
 import com.back.domain.donation.entity.DonationPayments;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class DonationPaymentDto {
 
@@ -42,12 +43,16 @@ public class DonationPaymentDto {
                     payments.getDonations().getId(),
                     payments.getMember().getId(),
                     payments.getDonations().getTitle(),
-                    payments.getDonations().getImageUrls().getFirst(),
+                    getFirstImageUrlOrNull(payments.getDonations().getImageUrls()),
                     payments.getAmount(),
                     payments.getPaymentMethod(),
                     payments.getCreatedAt()
             );
         }
+    }
+
+    private static String getFirstImageUrlOrNull(List<String> imageUrls) {
+        return (imageUrls == null || imageUrls.isEmpty()) ? null : imageUrls.getFirst();
     }
 
     public record RecentDonationPaymentListResponse(
@@ -68,7 +73,7 @@ public class DonationPaymentDto {
                     payments.getMember().getId(),
                     payments.getMember().getName(),
                     payments.getDonations().getTitle(),
-                    payments.getDonations().getImageUrls().getFirst(),
+                    getFirstImageUrlOrNull(payments.getDonations().getImageUrls()),
                     payments.getAmount(),
                     payments.getPaymentMethod(),
                     payments.getCreatedAt()

--- a/src/main/java/com/back/domain/feed/service/MemberTagStatisticsService.java
+++ b/src/main/java/com/back/domain/feed/service/MemberTagStatisticsService.java
@@ -7,6 +7,7 @@ import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,8 @@ public class MemberTagStatisticsService {
     private final MemberTagStatisticsRepository memberTagStatisticsRepository;
     private final FeedReactionRepository feedReactionRepository;
     private final MemberRepository memberRepository;
+    @Lazy
+    private final MemberTagStatisticsService self;
 
     // ========== 조회 ==========
 
@@ -43,7 +46,7 @@ public class MemberTagStatisticsService {
         if (statsOptional.isEmpty()) {
             // 통계가 없으면 즉시 생성
             log.info("통계 없음 - 즉시 생성: 회원 ID {}", memberId);
-            updateStatisticsSync(memberId);
+            self.updateStatisticsSync(memberId);
             statsOptional = memberTagStatisticsRepository.findByMemberId(memberId);
         }
         


### PR DESCRIPTION
readonly 트랜잭션에서 새로운 트랜잭션 생성 가능하게 수정

<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

-

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- nullable 한 donation image를 첫번쨰 이미지를 가져올 때 null 이 가능하게 수정
- readonly 트랜잭션에서 write 가능한 트랜잭션을 생성하기 위해 Lazy한 self를 만들어서 self가 메소드를 실행하게 수정

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #{이슈 번호}

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화
